### PR TITLE
验证码增加默认参数配置. 在 data/config.php 配置，定制个性化验证码。

### DIFF
--- a/simplewind/cmf/controller/CaptchaController.php
+++ b/simplewind/cmf/controller/CaptchaController.php
@@ -71,6 +71,11 @@ class CaptchaController
             $id = '';
         }
 
+        $defaultCaptchaConfig = config('captcha');
+        if($defaultCaptchaConfig && is_array($defaultCaptchaConfig)){
+            $config = array_merge($defaultCaptchaConfig, $config);
+        }
+
         $captcha = new Captcha($config);
         return $captcha->entry($id);
     }


### PR DESCRIPTION

## 说明
默认的验证码识别度太低了。看了一下 ThinkPHP 官方是支持很多配置的，但是 CMF 不支持。
为了不改变源码，复制了一个 CMF 核心验证码控制器，到模块。又新增一个路由指向到新路由，才实现需求。
现扩展了一下 CMF 核心文件，更加方便控制，也方便一下后来的使用者。


## 使用

可在data/config.php 配置 增加配置选项 captcha
```php
<?php
return array(
    'captcha' => [
        'useCurve' => false,
        'useNoise' => false,
      ],
);
```
> 配置选项，与原 ThinkPHP 验证码的配置参数 保持一致即可

这样可实现更多个性化验证码。

## 预览效果：

![image](https://user-images.githubusercontent.com/11265153/30301463-89cc713e-978d-11e7-88e7-4e6e31e12e95.png)

> 去除了干扰线和混淆字符。 （这里为了演示对比，同时去除了干扰线和混淆字符，使用时，请酌情选择）


