### PR TITLE
优化模板管理

### DIFF
--- a/app/admin/controller/ThemeController.php
+++ b/app/admin/controller/ThemeController.php
@@ -38,11 +38,11 @@ class ThemeController extends AdminBaseController
         $themes     = $themeModel->select();
         $this->assign("themes", $themes);
 
-        $default_theme = config('cmf_default_theme');
+        $defaultTheme = config('cmf_default_theme');
         if ($temp = session('cmf_default_theme')){
-            $default_theme = $temp;
+            $defaultTheme = $temp;
         }
-        $this->assign('default_theme', $default_theme);
+        $this->assign('default_theme', $defaultTheme);
         return $this->fetch();
     }
 

--- a/app/admin/controller/ThemeController.php
+++ b/app/admin/controller/ThemeController.php
@@ -183,6 +183,11 @@ class ThemeController extends AdminBaseController
     public function active()
     {
         $theme      = $this->request->param('theme');
+
+        if ($theme == config('cmf_default_theme')){
+            $this->error('模板已启用');
+        }
+
         $themeModel = new ThemeModel();
         $themeCount = $themeModel->where('theme', $theme)->count();
 
@@ -196,7 +201,7 @@ class ThemeController extends AdminBaseController
             $this->error('配置写入失败!');
         }
 
-        $this->success("模板已启用");
+        $this->success("模板启用成功");
 
     }
 

--- a/app/admin/controller/ThemeController.php
+++ b/app/admin/controller/ThemeController.php
@@ -95,6 +95,10 @@ class ThemeController extends AdminBaseController
     public function uninstall()
     {
         $theme      = $this->request->param('theme');
+        if ($theme == "simpleboot3" || config('cmf_default_theme') == $theme ){
+            $this->error("官方自带模板或当前使用中的模板不可以卸载");
+        }
+
         $themeModel = new ThemeModel();
         $themeModel->transaction(function () use ($theme, $themeModel) {
             $themeModel->where(['theme' => $theme])->delete();

--- a/app/admin/controller/ThemeController.php
+++ b/app/admin/controller/ThemeController.php
@@ -37,7 +37,12 @@ class ThemeController extends AdminBaseController
         $themeModel = new ThemeModel();
         $themes     = $themeModel->select();
         $this->assign("themes", $themes);
-        $this->assign('default_theme', config('cmf_default_theme'));
+
+        $default_theme = config('cmf_default_theme');
+        if ($temp = session('cmf_default_theme')){
+            $default_theme = $temp;
+        }
+        $this->assign('default_theme', $default_theme);
         return $this->fetch();
     }
 
@@ -185,7 +190,7 @@ class ThemeController extends AdminBaseController
         $theme      = $this->request->param('theme');
 
         if ($theme == config('cmf_default_theme')){
-            $this->error('模板已启用');
+            $this->error('模板已启用',url("theme/index"));
         }
 
         $themeModel = new ThemeModel();
@@ -200,8 +205,9 @@ class ThemeController extends AdminBaseController
         if ($result === false) {
             $this->error('配置写入失败!');
         }
+        session('cmf_default_theme',$theme);
 
-        $this->success("模板启用成功");
+        $this->success("模板启用成功",url("theme/index"));
 
     }
 

--- a/public/plugins/demo/controller/IndexController.php
+++ b/public/plugins/demo/controller/IndexController.php
@@ -14,14 +14,10 @@ use think\Db;
 class IndexController extends PluginBaseController
 {
 
-    function index($id)
+    function index()
     {
 
         $users = Db::name("user")->limit(0, 5)->select();
-        $demos=PluginDemoModel::all();
-
-       // print_r($demos);
-
         $this->assign("users", $users);
 
         return $this->fetch("/index");

--- a/public/themes/admin_simpleboot3/admin/theme/index.html
+++ b/public/themes/admin_simpleboot3/admin/theme/index.html
@@ -26,7 +26,7 @@
                     <td>
                         {$vo.theme}
                         <eq name="vo.theme" value="$default_theme">
-                            <span class="label label-success">当前使用</span>
+                            <span class="label label-success">当前启用</span>
                         </eq>
                     </td>
                     <td>{$vo.name}</td>
@@ -39,18 +39,29 @@
                         <a href="{:url('theme/update',array('theme'=>$vo['theme']))}" class="js-ajax-dialog-btn"
                            data-msg="确定更新此模板吗？">更新</a>
 
-                        <neq name="vo.theme" value="simpleboot3">
+
+                        <if condition="($vo.name == 'simpleboot3') OR ($vo.theme == $default_theme) ">
+                            <font color="#cccccc">卸载</font>
+                            <else />
+                            <a href="{:url('theme/uninstall',array('theme'=>$vo['theme']))}" class="js-ajax-dialog-btn"
+                               data-msg="您设置的模板数据将被删除，<br>确定卸载此模板吗？">卸载</a>
+                        </if>
 
 
-                        <a href="{:url('theme/uninstall',array('theme'=>$vo['theme']))}" class="js-ajax-dialog-btn"
-                           data-msg="您设置的模板数据将被删除，<br>确定卸载此模板吗？">卸载</a>
 
-                        </neq>
+                        <if condition="$vo.theme == $default_theme">
+                            <font color="#cccccc">启用</font>
+                            <else />
+                            <a href="{:url('theme/active',array('theme'=>$vo['theme']))}" class="js-ajax-dialog-btn"
+                               data-msg="确定使用此模板吗？">启用</a>
+                        </if>
 
 
 
-                        <a href="{:url('theme/active',array('theme'=>$vo['theme']))}" class="js-ajax-dialog-btn"
-                           data-msg="确定使用此模板吗？">使用</a>
+
+
+
+
                     </td>
                 </tr>
             </foreach>

--- a/public/themes/admin_simpleboot3/admin/theme/index.html
+++ b/public/themes/admin_simpleboot3/admin/theme/index.html
@@ -26,7 +26,7 @@
                     <td>
                         {$vo.theme}
                         <eq name="vo.theme" value="$default_theme">
-                            <span class="label label-success">默认</span>
+                            <span class="label label-success">当前使用</span>
                         </eq>
                     </td>
                     <td>{$vo.name}</td>
@@ -38,8 +38,17 @@
                         <a href="javascript:parent.openIframeLayer('{:url('theme/files',array('theme'=>$vo['theme']))}','{$vo.name}文件列表',{});">设计</a>
                         <a href="{:url('theme/update',array('theme'=>$vo['theme']))}" class="js-ajax-dialog-btn"
                            data-msg="确定更新此模板吗？">更新</a>
+
+                        <neq name="vo.theme" value="simpleboot3">
+
+
                         <a href="{:url('theme/uninstall',array('theme'=>$vo['theme']))}" class="js-ajax-dialog-btn"
                            data-msg="您设置的模板数据将被删除，<br>确定卸载此模板吗？">卸载</a>
+
+                        </neq>
+
+
+
                         <a href="{:url('theme/active',array('theme'=>$vo['theme']))}" class="js-ajax-dialog-btn"
                            data-msg="确定使用此模板吗？">使用</a>
                     </td>


### PR DESCRIPTION
1. 修改启用模板的Bug.该bug导致第一次启用时，默认的模板未跟随变化。似乎是thinkphp的问题。动态修改的配置,首次读取还是之前的值。
2、优化文案。默认修改为当前启用。使用  修改为 启用。
3、优化逻辑。官方自带的主题不可以被卸载。当前使用的主题不可以被卸载。已经启用的主题不可以再次启用。