### PR TITLE
//判断此分类有无子分类（不算被删除的子分类）

### DIFF
--- a/app/portal/controller/AdminCategoryController.php
+++ b/app/portal/controller/AdminCategoryController.php
@@ -263,8 +263,8 @@ tpl;
         if (empty($findCategory)) {
             $this->error('分类不存在!');
         }
-
-        $categoryChildrenCount = $portalCategoryModel->where('parent_id', $id)->count();
+//判断此分类有无子分类（不算被删除的子分类）
+        $categoryChildrenCount = $portalCategoryModel->where(['parent_id' => $id,'delete_time' => 0])->count();
 
         if ($categoryChildrenCount > 0) {
             $this->error('此分类有子类无法删除!');


### PR DESCRIPTION
如果我新建了子分类，然后再删除子分类，那么 父集分类就不能再被删除了，原因是未判断子分类中‘delete_time' => 0，导致了每次判断都有子分类。
我加了一个判断，经实测没有问题了