### PR TITLE
修改TP V5.0.18版本后 数组中使用exp查询和更新异常

### DIFF
--- a/simplewind/cmf/queue/connector/Database.php
+++ b/simplewind/cmf/queue/connector/Database.php
@@ -111,7 +111,7 @@ class Database extends DataBaseConnector
             ->update([
                 'reserved'     => 0,
                 'reserve_time' => null,
-                'attempts'     => ['exp', 'attempts + 1']
+                'attempts'     => $this->db->raw('attempts + 1')
             ]);
     }
 


### PR DESCRIPTION
V5.0.18+版本开始是数组中使用exp查询和更新的话，必须改成下面的方式：

Db::table('think_user')
    ->where('id', 1)
    ->update([
        'login_time'  => Db::raw('now()'),
        'login_times' => Db::raw('login_times+1'),
    ]);