### PR TITLE
修复幻灯片标签不能使用变量的bug

### DIFF
--- a/vendor/thinkcmf/cmf/src/lib/taglib/Cmf.php
+++ b/vendor/thinkcmf/cmf/src/lib/taglib/Cmf.php
@@ -327,6 +327,9 @@ parse;
     public function tagSlides($tag, $content)
     {
         $id    = empty($tag['id']) ? '0' : $tag['id'];
+        if (strpos($id, '$') === 0) {
+            $this->autoBuildVar($id);
+        }
         $item  = empty($tag['item']) ? 'vo' : $tag['item'];//循环变量名
         $parse = <<<parse
 <?php
@@ -347,6 +350,9 @@ parse;
     public function tagNoSlides($tag, $content)
     {
         $id    = empty($tag['id']) ? '0' : $tag['id'];
+        if (strpos($id, '$') === 0) {
+            $this->autoBuildVar($id);
+        }
         $parse = <<<parse
 <?php
     if(!isset(\$__SLIDE_ITEMS__)){


### PR DESCRIPTION
鉴于幻灯片`id`经常在配置文件中指定，而原先的代码中没有对`id`进行变量识别。现修复此缺憾。