### PR TITLE
这里应该优先使用OPENSSL解密

### DIFF
--- a/simplewind/extend/wxapp/aes/Prpcrypt.php
+++ b/simplewind/extend/wxapp/aes/Prpcrypt.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace wxapp\aes;
 
 /**
@@ -24,7 +25,12 @@ class Prpcrypt
     public function decrypt($aesCipher, $aesIV)
     {
 
-        if (function_exists('mcrypt_module_open')) {
+        if (function_exists('openssl_decrypt')) {
+
+            $decrypted = openssl_decrypt($aesCipher, 'AES-128-CBC', $this->key, OPENSSL_RAW_DATA, $aesIV);
+
+            if ($decrypted === false) return [ErrorCode::$IllegalBuffer, null];
+        } else if (function_exists('mcrypt_module_open')) {
             try {
 
                 $module = mcrypt_module_open(MCRYPT_RIJNDAEL_128, '', MCRYPT_MODE_CBC, '');
@@ -36,20 +42,16 @@ class Prpcrypt
                 mcrypt_generic_deinit($module);
                 mcrypt_module_close($module);
             } catch (\Exception $e) {
+
                 return [ErrorCode::$IllegalBuffer, null];
             }
-        } else if (function_exists('openssl_decrypt')) {
-
-            $decrypted = openssl_decrypt($aesCipher, 'AES-128-CBC', $this->key, OPENSSL_RAW_DATA, $aesIV);
-
-            if ($decrypted === false) return [ErrorCode::$IllegalBuffer, null];
         }
 
 
         try {
             //去除补位字符
             $pkc_encoder = new PKCS7Encoder;
-            $result      = $pkc_encoder->decode($decrypted);
+            $result = $pkc_encoder->decode($decrypted);
 
         } catch (\Exception $e) {
             //print $e;


### PR DESCRIPTION
在php7.1上，即使function_exists('mcrypt_module_open') 返回 true 但是下面 任然会出现异常  
[ error ] mcrypt_module_open_Exception
[ error ] Function mcrypt_module_open() is deprecated
日志是我自行加入在上面的第45行捕获出来的