### PR TITLE
修改模板配置文件重名时，以模板文件优先合并。

### DIFF
--- a/vendor/thinkcmf/cmf/src/controller/HomeBaseController.php
+++ b/vendor/thinkcmf/cmf/src/controller/HomeBaseController.php
@@ -213,7 +213,18 @@ hello;
                     }
 
                     $widget['vars']       = $widgetVars;
-                    $widgets[$widgetName] = $widget;
+                    //如果重名，则合并配置
+                    if (empty($widgets[$widgetName])) {
+                        $widgets[$widgetName] = $widget;
+                    } else {
+                        foreach ($widgets[$widgetName] as $key => $value) {
+                            if (is_array($widget[$key])) {
+                                $widgets[$widgetName][$key] = array_merge($widgets[$widgetName][$key], $widget[$key]);
+                            } else {
+                                $widgets[$widgetName][$key] = $widget[$key];
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/vendor/thinkcmf/cmf/src/lib/taglib/Cmf.php
+++ b/vendor/thinkcmf/cmf/src/lib/taglib/Cmf.php
@@ -31,7 +31,7 @@ class Cmf extends TagLib
         'slides'              => ['attr' => 'id', 'close' => 1],//非必须属性item
         'noslides'            => ['attr' => 'id', 'close' => 1],
         'captcha'             => ['attr' => 'height,width', 'close' => 0],//非必须属性font-size,length,bg,id
-        'hook'                => ['attr' => 'name,param', 'close' => 0]
+        'hook'                => ['attr' => 'name,param,once', 'close' => 0]
     ];
 
     /**
@@ -393,26 +393,17 @@ parse;
     {
         $name  = empty($tag['name']) ? '' : $tag['name'];
         $param = empty($tag['param']) ? '' : $tag['param'];
-        $extra = empty($tag['extra']) ? '' : $tag['extra'];
         $once  = empty($tag['once']) ? 'false' : 'true';
 
         if (empty($param)) {
-            //$param = '$temp' . uniqid();
             $param = 'null';
         } else if (strpos($param, '$') === false) {
             $this->autoBuildVar($param);
         }
 
-        if (empty($extra)) {
-            $extra = "null";
-        } else if (strpos($extra, '$') === false) {
-            $this->autoBuildVar($extra);
-        }
-
-
         $parse = <<<parse
 <php>
-    \\think\\facade\\Hook::listen('{$name}',{$param},{$extra},{$once});
+    \\think\\facade\\Hook::listen('{$name}',{$param},{$once});
 </php>
 parse;
         return $parse;


### PR DESCRIPTION
1. 主要为了应对不同页面，拥有相同模块，但配置不同的情况。比如点击排行，在不同的页面，排行文章分类不同，但模板完全相同，因此各页面只需配置文章分类即可。
2. 全局配置级别低于模板配置，这样在不需要单独配置的页面，即使用全局配置。