### PR TITLE
修复插件URL美化问题

### DIFF
--- a/vendor/thinkcmf/cmf/src/App.php
+++ b/vendor/thinkcmf/cmf/src/App.php
@@ -451,6 +451,7 @@ class App extends Container
             $routeInfo = $this->request->routeInfo();
             if (!empty($routeInfo['route']) && strpos($routeInfo['route'], '\cmf\controller\PluginController@index?') !== false) {
                 parse_str(str_replace('\cmf\controller\PluginController@index?', '', $routeInfo['route']), $routeParams);
+                $routeParams = array_merge($routeParams, $routeInfo['var']);
                 $this->request->withRoute($routeParams);
             }
 

--- a/vendor/thinkcmf/cmf/src/common.php
+++ b/vendor/thinkcmf/cmf/src/common.php
@@ -1176,7 +1176,7 @@ function cmf_plugin_url($url, $vars = [], $domain = false)
         foreach ($CMF_GV_routes[$pluginUrl] as $actionRoute) {
             $sameVars = array_intersect_assoc($vars, $actionRoute['vars']);
 
-            if (count($sameVars) == count($actionRoute['vars'])) {
+            if (!empty($sameVars) && (count($sameVars) == count($actionRoute['vars']))) {
                 ksort($sameVars);
                 $pluginUrl  = $pluginUrl . '&' . http_build_query($sameVars);
                 $vars = array_diff_assoc($vars, $sameVars);
@@ -1727,7 +1727,7 @@ function cmf_url($url = '', $vars = '', $suffix = true, $domain = false)
         foreach ($CMF_GV_routes[$url] as $actionRoute) {
             $sameVars = array_intersect_assoc($vars, $actionRoute['vars']);
 
-            if (count($sameVars) == count($actionRoute['vars'])) {
+            if (!empty($sameVars) && (count($sameVars) == count($actionRoute['vars']))) {
                 ksort($sameVars);
                 $url  = $url . '?' . http_build_query($sameVars);
                 $vars = array_diff_assoc($vars, $sameVars);


### PR DESCRIPTION
1、修复cmf_plugin_url以及cmf_url函数生成插件时，URL美化失败的BUG。
2、修复美化后，访问插件导致路由参数丢失的问题。