### PR TITLE
Update ThemeController.php

### DIFF
--- a/vendor/thinkcmf/cmf-app/src/admin/controller/ThemeController.php
+++ b/vendor/thinkcmf/cmf-app/src/admin/controller/ThemeController.php
@@ -724,7 +724,7 @@ class ThemeController extends AdminBaseController
                         }
                     }
 
-                    if (isset($post['widget_vars'])) {
+                    if (isset($post['widget_vars'])||isset($post['widget'])) {
                         foreach ($more['widgets'] as $mWidgetName => $widget) {
 
                             if (empty($post['widget'][$mWidgetName]['display'])) {


### PR DESCRIPTION
模板设计时，如果未设置widget_vars,会导致提交的widget.title和widget.display无法被保存，简单增加了widget提交时的判断