### PR TITLE
新参数数据第一次保存时无效,增加对中文的支持

### DIFF
--- a/vendor/thinkcmf/cmf/src/common.php
+++ b/vendor/thinkcmf/cmf/src/common.php
@@ -513,11 +513,11 @@ function cmf_set_option($key, $data, $replace = false)
             }
         }
 
-        $option['option_value'] = json_encode($data);
+        $option['option_value'] = json_encode($data,JSON_UNESCAPED_UNICODE);
         OptionModel::where('option_name', $key)->update($option);
     } else {
         $option['option_name']  = $key;
-        $option['option_value'] = json_encode($data);
+        $option['option_value'] = $data;
         OptionModel::create($option);
     }
 


### PR DESCRIPTION
optionModel中设置了option_value 类型为array 导致新参数数据第一次保存时无效，多出一个0下标元素。
增加对中文的支持。