### PR TITLE
修复未定义的ROOT_PATH常量为CMF_ROOT

### DIFF
--- a/vendor/thinkcmf/cmf-app/src/user/controller/UeditorController.php
+++ b/vendor/thinkcmf/cmf-app/src/user/controller/UeditorController.php
@@ -147,7 +147,7 @@ class UeditorController extends HomeBaseController
         $uploadMaxFileSize = $uploadSetting["image"]['upload_max_filesize'];
         $uploadMaxFileSize = empty($uploadMaxFileSize) ? 2048 : $uploadMaxFileSize;//默认2M
         $allowedExts       = explode(',', $uploadSetting["image"]["extensions"]);
-        $strSavePath       = ROOT_PATH . 'public' . DIRECTORY_SEPARATOR . "ueditor" . DIRECTORY_SEPARATOR . $date . DIRECTORY_SEPARATOR;
+        $strSavePath       = CMF_ROOT . 'public' . DIRECTORY_SEPARATOR . "ueditor" . DIRECTORY_SEPARATOR . $date . DIRECTORY_SEPARATOR;
         //远程抓取图片配置
         $config = [
             "savePath"   => $strSavePath,            //保存路径


### PR DESCRIPTION
ROOT_PATH未定义导致无法获取保存路径，建议修改为CMF_ROOT