### PR TITLE
修复TP5.1升级6.0时引入的验证器规则设置异常

### DIFF
--- a/vendor/thinkcmf/cmf-api/src/admin/controller/PublicController.php
+++ b/vendor/thinkcmf/cmf-api/src/admin/controller/PublicController.php
@@ -18,7 +18,8 @@ class PublicController extends RestBaseController
     // 用户登录 TODO 增加最后登录信息记录,如 ip
     public function login()
     {
-        $validate = new \think\Validate([
+        $validate = new \think\Validate();
+        $validate->rule([
             'username' => 'require',
             'password' => 'require'
         ]);

--- a/vendor/thinkcmf/cmf-api/src/user/controller/FavoritesController.php
+++ b/vendor/thinkcmf/cmf-api/src/user/controller/FavoritesController.php
@@ -108,10 +108,12 @@ class FavoritesController extends RestBaseController
     {
         $input = $this->request->param();
 
-        $validate = new Validate([
+        $validate = new Validate();
+        $validate->rule([
             'object_id'  => 'require',
             'table_name' => 'require'
-        ], [
+        ]);
+        $validate->message([
             'object_id.require'  => '请输出内容ID',
             'table_name.require' => '请输出内容ID所在表名不带前缀'
         ]);

--- a/vendor/thinkcmf/cmf-api/src/user/controller/ProfileController.php
+++ b/vendor/thinkcmf/cmf-api/src/user/controller/ProfileController.php
@@ -21,12 +21,12 @@ class ProfileController extends RestUserBaseController
      */
     public function changePassword()
     {
-        $validate = new Validate([
+        $validate = new Validate();
+        $validate->rule([
             'old_password'     => 'require',
             'password'         => 'require',
             'confirm_password' => 'require|confirm:password'
         ]);
-
         $validate->message([
             'old_password.require'     => '请输入您的旧密码!',
             'password.require'         => '请输入您的新密码!',
@@ -62,11 +62,11 @@ class ProfileController extends RestUserBaseController
      */
     public function bindingEmail()
     {
-        $validate = new Validate([
+        $validate = new Validate();
+        $validate->rule([
             'email'             => 'require|email|unique:user,user_email',
             'verification_code' => 'require'
         ]);
-
         $validate->message([
             'email.require'             => '请输入您的邮箱!',
             'email.email'               => '请输入正确的邮箱格式!',
@@ -106,11 +106,11 @@ class ProfileController extends RestUserBaseController
      */
     public function bindingMobile()
     {
-        $validate = new Validate([
+        $validate = new Validate();
+        $validate->rule([
             'mobile'            => 'require|unique:user,mobile',
             'verification_code' => 'require'
         ]);
-
         $validate->message([
             'mobile.require'            => '请输入您的手机号!',
             'mobile.unique'             => '手机号已经存在！',

--- a/vendor/thinkcmf/cmf-api/src/user/controller/PublicController.php
+++ b/vendor/thinkcmf/cmf-api/src/user/controller/PublicController.php
@@ -25,12 +25,12 @@ class PublicController extends RestBaseController
      */
     public function register()
     {
-        $validate = new \think\Validate([
+        $validate = new \think\Validate();
+        $validate->rule([
             'username'          => 'require',
             'password'          => 'require',
             'verification_code' => 'require'
         ]);
-
         $validate->message([
             'username.require'          => '请输入手机号,邮箱!',
             'password.require'          => '请输入您的密码!',
@@ -93,11 +93,11 @@ class PublicController extends RestBaseController
      */
     public function verificationCodeLogin()
     {
-        $validate = new \think\Validate([
+        $validate = new \think\Validate();
+        $validate->rule([
             'username'          => 'require',
             'verification_code' => 'require'
         ]);
-
         $validate->message([
             'username.require'          => '请输入手机号,邮箱!',
             'verification_code.require' => '请输入数字验证码!'
@@ -202,7 +202,8 @@ class PublicController extends RestBaseController
     // TODO 增加最后登录信息记录,如 ip
     public function login()
     {
-        $validate = new \think\Validate([
+        $validate = new \think\Validate();
+        $validate->rule([
             'username' => 'require',
             'password' => 'require'
         ]);
@@ -316,12 +317,12 @@ class PublicController extends RestBaseController
      */
     public function passwordReset()
     {
-        $validate = new \think\Validate([
+        $validate = new \think\Validate();
+        $validate->rule([
             'username'          => 'require',
             'password'          => 'require',
             'verification_code' => 'require'
         ]);
-
         $validate->message([
             'username.require'          => '请输入手机号,邮箱!',
             'password.require'          => '请输入您的密码!',

--- a/vendor/thinkcmf/cmf-api/src/user/controller/VerificationCodeController.php
+++ b/vendor/thinkcmf/cmf-api/src/user/controller/VerificationCodeController.php
@@ -26,10 +26,10 @@ class VerificationCodeController extends RestBaseController
      */
     public function send()
     {
-        $validate = new \think\Validate([
+        $validate = new \think\Validate();
+        $validate->rule([
             'username' => 'require',
         ]);
-
         $validate->message([
             'username.require' => '请输入手机号或邮箱!',
         ]);

--- a/vendor/thinkcmf/cmf-api/src/wxapp/controller/PublicController.php
+++ b/vendor/thinkcmf/cmf-api/src/wxapp/controller/PublicController.php
@@ -18,14 +18,14 @@ class PublicController extends RestBaseController
     // 微信小程序用户登录 TODO 增加最后登录信息记录,如 ip
     public function login()
     {
-        $validate = new Validate([
+        $validate = new Validate();
+        $validate->rule([
             'code'           => 'require',
             'encrypted_data' => 'require',
             'iv'             => 'require',
             'raw_data'       => 'require',
             'signature'      => 'require',
         ]);
-
         $validate->message([
             'code.require'           => '缺少参数code!',
             'encrypted_data.require' => '缺少参数encrypted_data!',

--- a/vendor/thinkcmf/cmf-app/src/admin/controller/MailerController.php
+++ b/vendor/thinkcmf/cmf-app/src/admin/controller/MailerController.php
@@ -141,7 +141,8 @@ class MailerController extends AdminBaseController
     {
         if ($this->request->isPost()) {
 
-            $validate = new Validate([
+            $validate = new Validate();
+            $validate->rule([
                 'to'      => 'require|email',
                 'subject' => 'require',
                 'content' => 'require',

--- a/vendor/thinkcmf/cmf-app/src/user/controller/LoginController.php
+++ b/vendor/thinkcmf/cmf-app/src/user/controller/LoginController.php
@@ -47,7 +47,8 @@ class LoginController extends HomeBaseController
     public function doLogin()
     {
         if ($this->request->isPost()) {
-            $validate = new \think\Validate([
+            $validate = new \think\Validate();
+            $validate->rule([
                 'captcha'  => 'require',
                 'username' => 'require',
                 'password' => 'require|min:6|max:32',
@@ -120,7 +121,8 @@ class LoginController extends HomeBaseController
     {
 
         if ($this->request->isPost()) {
-            $validate = new \think\Validate([
+            $validate = new \think\Validate();
+            $validate->rule([
                 'captcha'           => 'require',
                 'verification_code' => 'require',
                 'password'          => 'require|min:6|max:32',

--- a/vendor/thinkcmf/cmf-app/src/user/controller/ProfileController.php
+++ b/vendor/thinkcmf/cmf-app/src/user/controller/ProfileController.php
@@ -51,7 +51,8 @@ class ProfileController extends UserBaseController
     public function editPost()
     {
         if ($this->request->isPost()) {
-            $validate = new Validate([
+            $validate = new Validate();
+            $validate->rule([
                 'user_nickname' => 'max:32',
                 'sex'           => 'between:0,2',
                 'birthday'      => 'dateFormat:Y-m-d|after:-88 year|before:-1 day',
@@ -100,7 +101,8 @@ class ProfileController extends UserBaseController
     public function passwordPost()
     {
         if ($this->request->isPost()) {
-            $validate = new Validate([
+            $validate = new Validate();
+            $validate->rule([
                 'old_password' => 'require|min:6|max:32',
                 'password'     => 'require|min:6|max:32',
                 'repassword'   => 'require|min:6|max:32',
@@ -251,7 +253,8 @@ class ProfileController extends UserBaseController
     public function bindingMobile()
     {
         if ($this->request->isPost()) {
-            $validate = new Validate([
+            $validate = new Validate();
+            $validate->rule([
                 'username'          => 'require|number|unique:user,mobile',
                 'verification_code' => 'require',
             ]);
@@ -290,7 +293,8 @@ class ProfileController extends UserBaseController
     public function bindingEmail()
     {
         if ($this->request->isPost()) {
-            $validate = new Validate([
+            $validate = new Validate();
+            $validate->rule([
                 'username'          => 'require|email|unique:user,user_email',
                 'verification_code' => 'require',
             ]);

--- a/vendor/thinkcmf/cmf-app/src/user/controller/VerificationCodeController.php
+++ b/vendor/thinkcmf/cmf-app/src/user/controller/VerificationCodeController.php
@@ -20,11 +20,11 @@ class VerificationCodeController extends HomeBaseController
         if (!$this->request->isPost()) {
             $this->error('非法请求！');
         }
-        $validate = new \think\Validate([
+        $validate = new \think\Validate();
+        $validate->rule([
             'username' => 'require',
             'captcha'  => 'require',
         ]);
-
         $validate->message([
             'username.require' => '请输入手机号或邮箱!',
             'captcha.require'  => '图片验证码不能为空',


### PR DESCRIPTION
修复TP5.1升级6.0时引入的验证器规则设置异常,将验证规则改为通过rule()方法的形式进行设置。